### PR TITLE
Fix issue when Poison is not compiled first

### DIFF
--- a/lib/currencies.ex
+++ b/lib/currencies.ex
@@ -9,21 +9,22 @@ defmodule Currencies do
   alias Currencies.MinorUnit
 
   # Pre-loads currency data at compile time
-  data_path = fn (path) ->
-    Path.join("data", path) |> Path.expand(__DIR__)
+  if Code.ensure_compiled(Poison) do
+    data_path = fn (path) ->
+      Path.join("data", path) |> Path.expand(__DIR__)
+    end
+
+    load_currency = fn(currency_code) ->
+        data_path.(Path.join("currencies", String.downcase(currency_code) <> ".json"))
+          |> File.read!
+          |> Poison.decode!(as: %Currency{representations: %Representations{}, minor_unit: %MinorUnit{}, central_bank: %CentralBank{}})
+    end
+
+    @currencies data_path.("currencies.json")
+      |> File.read!
+      |> Poison.decode!(as: [ %Currency{} ])
+      |> Enum.map(&(load_currency.(&1.code)))
   end
-
-  load_currency = fn(currency_code) ->
-      data_path.(Path.join("currencies", String.downcase(currency_code) <> ".json"))
-        |> File.read!
-        |> Poison.decode!(as: %Currency{representations: %Representations{}, minor_unit: %MinorUnit{}, central_bank: %CentralBank{}})
-  end
-
-  @currencies data_path.("currencies.json")
-    |> File.read!
-    |> Poison.decode!(as: [ %Currency{} ])
-    |> Enum.map(&(load_currency.(&1.code)))
-
   @doc """
   Returns all currencies matching the given predicate
 


### PR DESCRIPTION
Hi @JakeStaTeresa 
In my use case of [Currencies](https://github.com/JakeStaTeresa/Currencies) in a [Phoenix](https://github.com/phoenixframework/phoenix) app, [Currencies](https://github.com/JakeStaTeresa/Currencies) got compiled before [Poison](https://github.com/devinus/poison) this fix make sure that [Poison](https://github.com/devinus/poison) is compiled first.

Thanks for the this module ❤️ 